### PR TITLE
feat: Create the `wasmer.target` submodule to support cross-compilation

### DIFF
--- a/Cargo.lock
+++ b/Cargo.lock
@@ -1237,6 +1237,7 @@ dependencies = [
 name = "wasmer-common-python"
 version = "0.5.0"
 dependencies = [
+ "enumset",
  "pyo3",
  "wasmer",
  "wasmer-compiler",

--- a/docs/api/engine/index.html
+++ b/docs/api/engine/index.html
@@ -69,25 +69,29 @@ engine = engine.JIT(Compiler)
 <dl>
 <dt id="engine.JIT"><code class="flex name class">
 <span>class <span class="ident">JIT</span></span>
-<span>(</span><span>compiler, /)</span>
+<span>(</span><span>compiler, target, /)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>JIT engine for Wasmer compilers.</p>
-<p>Given an option compiler, it generates the compiled machine code,
+<p>Given an optional compiler, it generates the compiled machine code,
 and publishes it into memory so it can be used externally.</p>
-<p>If the compiler is absent, it will generate a headless engine.</p></div>
+<p>If the compiler is absent, it will generate a headless engine.</p>
+<p>It is possible to specify a <code>Target</code> to possibly cross-compile for
+a different target. It requires a compiler.</p></div>
 </dd>
 <dt id="engine.Native"><code class="flex name class">
 <span>class <span class="ident">Native</span></span>
-<span>(</span><span>compiler, /)</span>
+<span>(</span><span>compiler, target, /)</span>
 </code></dt>
 <dd>
 <div class="desc"><p>Native engine for Wasmer compilers.</p>
-<p>Given an option compiler, it generates a shared object file
+<p>Given an optional compiler, it generates a shared object file
 (<code>.so</code>, <code>.dylib</code> or <code>.dll</code> depending on the target), saves it
 temporarily to disk and uses it natively via <code>dlopen</code> and <code>dlsym</code>.
 and publishes it into memory so it can be used externally.</p>
-<p>If the compiler is absent, it will generate a headless engine.</p></div>
+<p>If the compiler is absent, it will generate a headless engine.</p>
+<p>It is possible to specify a <code>Target</code> to possibly cross-compile for
+a different target. It requires a compiler.</p></div>
 </dd>
 </dl>
 </section>

--- a/docs/api/target/index.html
+++ b/docs/api/target/index.html
@@ -1,0 +1,296 @@
+<!doctype html>
+<html lang="en">
+<head>
+<meta charset="utf-8">
+<meta name="viewport" content="width=device-width, initial-scale=1, minimum-scale=1" />
+<meta name="generator" content="pdoc 0.9.2.dev1+gad6a554" />
+<title>target API documentation</title>
+<meta name="description" content="Wasmer&#39;s compilation targets …" />
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/sanitize.min.css" integrity="sha256-PK9q560IAAa6WVRRh76LtCaI8pjTJ2z11v0miyNNjrs=" crossorigin>
+<link rel="preload stylesheet" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/10up-sanitize.css/11.0.1/typography.min.css" integrity="sha256-7l/o7C8jubJiy74VsKTidCy1yBkRtiUGbVkYBylBqUg=" crossorigin>
+<link rel="stylesheet preload" as="style" href="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/styles/github.min.css" crossorigin>
+<style>:root{--highlight-color:#fe9}.flex{display:flex !important}body{line-height:1.5em}#content{padding:20px}#sidebar{padding:30px;overflow:hidden}#sidebar > *:last-child{margin-bottom:2cm}.http-server-breadcrumbs{font-size:130%;margin:0 0 15px 0}#footer{font-size:.75em;padding:5px 30px;border-top:1px solid #ddd;text-align:right}#footer p{margin:0 0 0 1em;display:inline-block}#footer p:last-child{margin-right:30px}h1,h2,h3,h4,h5{font-weight:300}h1{font-size:2.5em;line-height:1.1em}h2{font-size:1.75em;margin:1em 0 .50em 0}h3{font-size:1.4em;margin:25px 0 10px 0}h4{margin:0;font-size:105%}h1:target,h2:target,h3:target,h4:target,h5:target,h6:target{background:var(--highlight-color);padding:.2em 0}a{color:#058;text-decoration:none;transition:color .3s ease-in-out}a:hover{color:#e82}.title code{font-weight:bold}h2[id^="header-"]{margin-top:2em}.ident{color:#900}pre code{background:#f8f8f8;font-size:.8em;line-height:1.4em}code{background:#f2f2f1;padding:1px 4px;overflow-wrap:break-word}h1 code{background:transparent}pre{background:#f8f8f8;border:0;border-top:1px solid #ccc;border-bottom:1px solid #ccc;margin:1em 0;padding:1ex}#http-server-module-list{display:flex;flex-flow:column}#http-server-module-list div{display:flex}#http-server-module-list dt{min-width:10%}#http-server-module-list p{margin-top:0}.toc ul,#index{list-style-type:none;margin:0;padding:0}#index code{background:transparent}#index h3{border-bottom:1px solid #ddd}#index ul{padding:0}#index h4{margin-top:.6em;font-weight:bold}@media (min-width:200ex){#index .two-column{column-count:2}}@media (min-width:300ex){#index .two-column{column-count:3}}dl{margin-bottom:2em}dl dl:last-child{margin-bottom:4em}dd{margin:0 0 1em 3em}#header-classes + dl > dd{margin-bottom:3em}dd dd{margin-left:2em}dd p{margin:10px 0}.name{background:#eee;font-weight:bold;font-size:.85em;padding:5px 10px;display:inline-block;min-width:40%}.name:hover{background:#e0e0e0}dt:target .name{background:var(--highlight-color)}.name > span:first-child{white-space:nowrap}.name.class > span:nth-child(2){margin-left:.4em}.inherited{color:#999;border-left:5px solid #eee;padding-left:1em}.inheritance em{font-style:normal;font-weight:bold}.desc h2{font-weight:400;font-size:1.25em}.desc h3{font-size:1em}.desc dt code{background:inherit}.source summary,.git-link-div{color:#666;text-align:right;font-weight:400;font-size:.8em;text-transform:uppercase}.source summary > *{white-space:nowrap;cursor:pointer}.git-link{color:inherit;margin-left:1em}.source pre{max-height:500px;overflow:auto;margin:0}.source pre code{font-size:12px;overflow:visible}.hlist{list-style:none}.hlist li{display:inline}.hlist li:after{content:',\2002'}.hlist li:last-child:after{content:none}.hlist .hlist{display:inline;padding-left:1em}img{max-width:100%}td{padding:0 .5em}.admonition{padding:.1em .5em;margin-bottom:1em}.admonition-title{font-weight:bold}.admonition.note,.admonition.info,.admonition.important{background:#aef}.admonition.todo,.admonition.versionadded,.admonition.tip,.admonition.hint{background:#dfd}.admonition.warning,.admonition.versionchanged,.admonition.deprecated{background:#fd4}.admonition.error,.admonition.danger,.admonition.caution{background:lightpink}</style>
+<style media="screen and (min-width: 700px)">@media screen and (min-width:700px){#sidebar{width:30%;height:100vh;overflow:auto;position:sticky;top:0}#content{width:70%;max-width:100ch;padding:3em 4em;border-left:1px solid #ddd}pre code{font-size:1em}.item .name{font-size:1em}main{display:flex;flex-direction:row-reverse;justify-content:flex-end}.toc ul ul,#index ul{padding-left:1.5em}.toc > ul > li{margin-top:.5em}}</style>
+<style media="print">@media print{#sidebar h1{page-break-before:always}.source{display:none}}@media print{*{background:transparent !important;color:#000 !important;box-shadow:none !important;text-shadow:none !important}a[href]:after{content:" (" attr(href) ")";font-size:90%}a[href][title]:after{content:none}abbr[title]:after{content:" (" attr(title) ")"}.ir a:after,a[href^="javascript:"]:after,a[href^="#"]:after{content:""}pre,blockquote{border:1px solid #999;page-break-inside:avoid}thead{display:table-header-group}tr,img{page-break-inside:avoid}img{max-width:100% !important}@page{margin:0.5cm}p,h2,h3{orphans:3;widows:3}h1,h2,h3,h4,h5,h6{page-break-after:avoid}}</style>
+<script defer src="https://cdnjs.cloudflare.com/ajax/libs/highlight.js/10.1.1/highlight.min.js" integrity="sha256-Uv3H6lx7dJmRfRvH8TH6kJD1TSK1aFcwgx+mdg3epi8=" crossorigin></script>
+<script>window.addEventListener('DOMContentLoaded', () => hljs.initHighlighting())</script>
+</head>
+<body>
+<main>
+<article id="content">
+<header>
+<h1 class="title">Module <code>target</code></h1>
+</header>
+<section id="section-intro">
+<p>Wasmer's compilation targets.</p>
+<p>Wasmer has several compilers used by the engines (<code>wasmer.engine</code>)
+when a WebAssembly module needs to be compiled. The Wasmer's
+architecture allows to compile for any targets. It allows to
+cross-compile a WebAssembly module, i.e. to compile from another
+architecture than the host's.</p>
+<p>This module provides the <code><a title="target.Target" href="#target.Target">Target</a></code> class that allows to define a
+target for the compiler. A <code><a title="target.Target" href="#target.Target">Target</a></code> is defined by a <code><a title="target.Triple" href="#target.Triple">Triple</a></code> and
+<code><a title="target.CpuFeatures" href="#target.CpuFeatures">CpuFeatures</a></code> (optional).</p>
+<h2 id="example">Example</h2>
+<pre><code class="py">from wasmer import engine, target, Store, Module
+from wasmer_compiler_cranelift import Compiler
+
+# Build a triple from a string.
+triple = target.Triple('x86_64-linux-musl')
+
+# Build the CPU features (optional).
+cpu_features = target.CpuFeatures()
+cpu_features.add('sse2')
+
+# Build the target.
+target = target.Target(triple, cpu_features)
+
+# There we go. When creating the engine, pass the compiler _and_
+# the target.
+engine = engine.Native(Compiler, target)
+
+# And finally, build the store with the engine.
+store = Store(engine)
+
+# Now, let's compile the module for the defined target.
+module = Module(
+    store,
+    &quot;&quot;&quot;
+    (module
+    (type $sum_t (func (param i32 i32) (result i32)))
+    (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
+        local.get $x
+        local.get $y
+        i32.add)
+    (export &quot;sum&quot; (func $sum_f)))
+    &quot;&quot;&quot;
+)
+
+# What's next? Serialize the module, and execute it on the
+# targeted host.
+</code></pre>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+</section>
+<section>
+<h2 class="section-title" id="header-classes">Classes</h2>
+<dl>
+<dt id="target.CpuFeatures"><code class="flex name class">
+<span>class <span class="ident">CpuFeatures</span></span>
+</code></dt>
+<dd>
+<div class="desc"><p>Represents a set of CPU features.</p>
+<p>CPU features are identified by their stringified names. The
+reference is the GCC options:</p>
+<ul>
+<li><a href="https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html">https://gcc.gnu.org/onlinedocs/gcc/x86-Options.html</a></li>
+<li><a href="https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html">https://gcc.gnu.org/onlinedocs/gcc/ARM-Options.html</a></li>
+<li><a href="https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html">https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html</a></li>
+</ul>
+<p>At the time of writing this documentation (it might be outdated in
+the future), the supported features are the following:</p>
+<ul>
+<li><code>sse2</code>,</li>
+<li><code>sse3</code>,</li>
+<li><code>ssse3</code>,</li>
+<li><code>sse4.1</code>,</li>
+<li><code>sse4.2</code>,</li>
+<li><code>popcnt</code>,</li>
+<li><code>avx</code>,</li>
+<li><code>bmi</code>,</li>
+<li><code>bmi2</code>,</li>
+<li><code>avx2</code>,</li>
+<li><code>avx512dq</code>,</li>
+<li><code>avx512vl</code>,</li>
+<li><code>lzcnt</code>.</li>
+</ul>
+<h2 id="example">Example</h2>
+<pre><code class="py">from wasmer import target
+
+cpu_features = target.CpuFeatures()
+cpu_features.add('sse2')
+</code></pre></div>
+<h3>Methods</h3>
+<dl>
+<dt id="target.CpuFeatures.add"><code class="name flex">
+<span>def <span class="ident">add</span></span>(<span>self, /, feature)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Add a new CPU feature.</p></div>
+</dd>
+</dl>
+</dd>
+<dt id="target.Target"><code class="flex name class">
+<span>class <span class="ident">Target</span></span>
+<span>(</span><span>triple, cpu_features)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Represents a <code><a title="target.Triple" href="#target.Triple">Triple</a></code> + <code><a title="target.CpuFeatures" href="#target.CpuFeatures">CpuFeatures</a></code> pair.</p>
+<p>If the <code><a title="target.CpuFeatures" href="#target.CpuFeatures">CpuFeatures</a></code> is ommited, an empty set of CPU feature will
+be assumed.</p>
+<h2 id="example">Example</h2>
+<pre><code class="py">from wasmer import target
+
+triple = target.Triple('x86_64-apple-darwin')
+
+cpu_features = target.CpuFeatures()
+cpu_features.add('sse2')
+
+target = target.Target(triple, cpu_features)
+</code></pre></div>
+</dd>
+<dt id="target.Triple"><code class="flex name class">
+<span>class <span class="ident">Triple</span></span>
+<span>(</span><span>triple)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>A target “triple”.</p>
+<p>Historically such things had three fields, though they have added
+additional fields over time.</p>
+<h2 id="example">Example</h2>
+<pre><code class="py">from wasmer import target
+
+triple = target.Triple('x86_64-apple-darwin')
+
+assert str(triple) == 'x86_64-apple-darwin'
+assert triple.architecture == 'x86_64'
+assert triple.vendor == 'apple'
+assert triple.operating_system == 'darwin'
+assert triple.binary_format == 'macho'
+assert triple.environment == 'unknown'
+assert triple.endianness == 'little'
+assert triple.pointer_width == 8
+assert triple.default_calling_convention == 'system_v'
+</code></pre></div>
+<h3>Static methods</h3>
+<dl>
+<dt id="target.Triple.host"><code class="name flex">
+<span>def <span class="ident">host</span></span>(<span>...)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Build the triple for the current host.</p>
+<h2 id="example">Example</h2>
+<pre><code class="py">from wasmer import target
+
+this_triple = target.Triple.host()
+</code></pre></div>
+</dd>
+</dl>
+<h3>Instance variables</h3>
+<dl>
+<dt id="target.Triple.architecture"><code class="name">var <span class="ident">architecture</span></code></dt>
+<dd>
+<div class="desc"><p>Returns the “architecture” (and sometimes the subarchitecture).</p></div>
+</dd>
+<dt id="target.Triple.binary_format"><code class="name">var <span class="ident">binary_format</span></code></dt>
+<dd>
+<div class="desc"><p>Returns the “binary format” (rarely used).</p></div>
+</dd>
+<dt id="target.Triple.default_calling_convention"><code class="name">var <span class="ident">default_calling_convention</span></code></dt>
+<dd>
+<div class="desc"><p>Returns the default calling convention for the given target
+triple.</p>
+<p>The calling convention specifies things like which registers
+are used for passing arguments, which registers are
+callee-saved, and so on.</p>
+<p>Possible returned values are:</p>
+<ul>
+<li><code>system_v</code>, “System V” which is used on most Unix-like platfoms. Note
+that the specific conventions vary between hardware
+architectures; for example, x86-32's “System V” is entirely
+different from x86-64's “System V”.</li>
+<li><code>wasm_basic_c_abi</code>, <a href="https://github.com/WebAssembly/tool-conventions/blob/master/BasicCABI.md">The WebAssembly C
+ABI</a>.</li>
+<li><code>windows_fastcall</code>, “Windows Fastcall” which is used on
+Windows. Note that like “System V”, this varies between
+hardware architectures. On x86-32 it describes what Windows
+documentation calls “fastcall”, and on x86-64 it describes
+what Windows documentation often just calls the Windows x64
+calling convention (though the compiler still recognizes
+“fastcall” as an alias for it).</li>
+</ul></div>
+</dd>
+<dt id="target.Triple.endianness"><code class="name">var <span class="ident">endianness</span></code></dt>
+<dd>
+<div class="desc"><p>Returns the endianness of this target's architecture.</p>
+<p>Possible returned values are <code>little</code> or <code>big</code>.</p></div>
+</dd>
+<dt id="target.Triple.environment"><code class="name">var <span class="ident">environment</span></code></dt>
+<dd>
+<div class="desc"><p>Returns the “environment” on top of the operating system
+(often omitted for operating systems with a single predominant
+environment).</p></div>
+</dd>
+<dt id="target.Triple.operating_system"><code class="name">var <span class="ident">operating_system</span></code></dt>
+<dd>
+<div class="desc"><p>Returns the "operating system” (sometimes also the environment).</p></div>
+</dd>
+<dt id="target.Triple.pointer_width"><code class="name">var <span class="ident">pointer_width</span></code></dt>
+<dd>
+<div class="desc"><p>Returns the pointer width (in bytes) of this target's
+architecture.</p>
+<p>The width of a pointer (in the default address space) can be
+of size <code>u16</code>, <code>u32</code> or <code>u64</code>, resp. 2, 4 or 8 bytes, which
+are the possible returned values.</p></div>
+</dd>
+<dt id="target.Triple.vendor"><code class="name">var <span class="ident">vendor</span></code></dt>
+<dd>
+<div class="desc"><p>Returns the “vendor” (whatever that means).</p></div>
+</dd>
+</dl>
+</dd>
+</dl>
+</section>
+</article>
+<nav id="sidebar">
+<h1>Index</h1>
+<div class="toc">
+<ul>
+<li><a href="#example">Example</a></li>
+</ul>
+</div>
+<ul id="index">
+<li><h3>Super-module</h3>
+<ul>
+<li><code><a title="wasmer" href="../wasmer/index.html">wasmer</a></code></li>
+</ul>
+</li>
+<li><h3><a href="#header-classes">Classes</a></h3>
+<ul>
+<li>
+<h4><code><a title="target.CpuFeatures" href="#target.CpuFeatures">CpuFeatures</a></code></h4>
+<ul class="">
+<li><code><a title="target.CpuFeatures.add" href="#target.CpuFeatures.add">add</a></code></li>
+</ul>
+</li>
+<li>
+<h4><code><a title="target.Target" href="#target.Target">Target</a></code></h4>
+</li>
+<li>
+<h4><code><a title="target.Triple" href="#target.Triple">Triple</a></code></h4>
+<ul class="">
+<li><code><a title="target.Triple.architecture" href="#target.Triple.architecture">architecture</a></code></li>
+<li><code><a title="target.Triple.binary_format" href="#target.Triple.binary_format">binary_format</a></code></li>
+<li><code><a title="target.Triple.default_calling_convention" href="#target.Triple.default_calling_convention">default_calling_convention</a></code></li>
+<li><code><a title="target.Triple.endianness" href="#target.Triple.endianness">endianness</a></code></li>
+<li><code><a title="target.Triple.environment" href="#target.Triple.environment">environment</a></code></li>
+<li><code><a title="target.Triple.host" href="#target.Triple.host">host</a></code></li>
+<li><code><a title="target.Triple.operating_system" href="#target.Triple.operating_system">operating_system</a></code></li>
+<li><code><a title="target.Triple.pointer_width" href="#target.Triple.pointer_width">pointer_width</a></code></li>
+<li><code><a title="target.Triple.vendor" href="#target.Triple.vendor">vendor</a></code></li>
+</ul>
+</li>
+</ul>
+</li>
+</ul>
+</nav>
+</main>
+<footer id="footer">
+<p>Generated by <a href="https://pdoc3.github.io/pdoc"><cite>pdoc</cite> 0.9.2.dev1+gad6a554</a>.</p>
+</footer>
+</body>
+</html>

--- a/docs/api/wasmer/index.html
+++ b/docs/api/wasmer/index.html
@@ -78,6 +78,10 @@ buffer protocol with <code><a title="wasmer.Buffer" href="#wasmer.Buffer">Buffer
 <dd>
 <div class="desc"><p>Wasmer Engines …</p></div>
 </dd>
+<dt><code class="name"><a title="target" href="../target/index.html">target</a></code></dt>
+<dd>
+<div class="desc"><p>Wasmer's compilation targets …</p></div>
+</dd>
 <dt><code class="name"><a title="wasi" href="../wasi/index.html">wasi</a></code></dt>
 <dd>
 <div class="desc"><p>Wasmer's <a href="https://github.com/WebAssembly/WASI">WASI</a>
@@ -1241,7 +1245,7 @@ have been allocated during the lifetime of the abstract machine.</p>
 <p>The <code><a title="wasmer.Store" href="#wasmer.Store">Store</a></code> holds the engine (that is —amongst many things— used
 to compile the WebAssembly bytes into a valid module artifact), in
 addition to the <code>Tunables</code> (that are used to create the memories,
-tables and globals). The engine comes from the <code>wasmer.engines</code>
+tables and globals). The engine comes from the <code>wasmer.engine</code>
 module.</p>
 <p>Specification: <a href="https://webassembly.github.io/spec/core/exec/runtime.html#store">https://webassembly.github.io/spec/core/exec/runtime.html#store</a></p>
 <p>Read the documentation of the <code><a title="engine" href="../engine/index.html">engine</a></code> submodule to learn more.</p>
@@ -1595,6 +1599,7 @@ value = Value.v128(42)
 <li><h3><a href="#header-submodules">Sub-modules</a></h3>
 <ul>
 <li><code><a title="engine" href="../engine/index.html">engine</a></code></li>
+<li><code><a title="target" href="../target/index.html">target</a></code></li>
 <li><code><a title="wasi" href="../wasi/index.html">wasi</a></code></li>
 </ul>
 </li>

--- a/packages/api/src/lib.rs
+++ b/packages/api/src/lib.rs
@@ -222,7 +222,58 @@ fn engine(_py: Python, module: &PyModule) -> PyResult<()> {
     Ok(())
 }
 
-/// Targets.
+/// Wasmer's compilation targets.
+///
+/// Wasmer has several compilers used by the engines (`wasmer.engine`)
+/// when a WebAssembly module needs to be compiled. The Wasmer's
+/// architecture allows to compile for any targets. It allows to
+/// cross-compile a WebAssembly module, i.e. to compile from another
+/// architecture than the host's.
+///
+/// This module provides the `Target` class that allows to define a
+/// target for the compiler. A `Target` is defined by a `Triple` and
+/// `CpuFeatures` (optional).
+///
+/// ## Example
+///
+/// ```py
+/// from wasmer import engine, target, Store, Module
+/// from wasmer_compiler_cranelift import Compiler
+///
+/// # Build a triple from a string.
+/// triple = target.Triple('x86_64-linux-musl')
+///
+/// # Build the CPU features (optional).
+/// cpu_features = target.CpuFeatures()
+/// cpu_features.add('sse2')
+///
+/// # Build the target.
+/// target = target.Target(triple, cpu_features)
+///
+/// # There we go. When creating the engine, pass the compiler _and_
+/// # the target.
+/// engine = engine.Native(Compiler, target)
+///
+/// # And finally, build the store with the engine.
+/// store = Store(engine)
+///
+/// # Now, let's compile the module for the defined target.
+/// module = Module(
+///     store,
+///     """
+///     (module
+///     (type $sum_t (func (param i32 i32) (result i32)))
+///     (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
+///         local.get $x
+///         local.get $y
+///         i32.add)
+///     (export "sum" (func $sum_f)))
+///     """
+/// )
+///
+/// # What's next? Serialize the module, and execute it on the
+/// # targeted host.
+/// ```
 #[pymodule]
 fn target(_py: Python, module: &PyModule) -> PyResult<()> {
     // Classes.

--- a/packages/api/src/lib.rs
+++ b/packages/api/src/lib.rs
@@ -19,6 +19,7 @@ mod instance;
 mod memory;
 mod module;
 mod store;
+mod target;
 mod types;
 mod values;
 mod wasi;
@@ -162,6 +163,7 @@ fn wasmer(py: Python, module: &PyModule) -> PyResult<()> {
 
     // Modules.
     module.add_wrapped(wrap_pymodule!(engine))?;
+    module.add_wrapped(wrap_pymodule!(target))?;
     module.add_wrapped(wrap_pymodule!(wasi))?;
 
     Ok(())
@@ -216,6 +218,17 @@ fn engine(_py: Python, module: &PyModule) -> PyResult<()> {
     // Classes.
     module.add_class::<engines::JIT>()?;
     module.add_class::<engines::Native>()?;
+
+    Ok(())
+}
+
+/// Targets.
+#[pymodule]
+fn target(_py: Python, module: &PyModule) -> PyResult<()> {
+    // Classes.
+    module.add_class::<target::Target>()?;
+    module.add_class::<target::Triple>()?;
+    module.add_class::<target::CpuFeatures>()?;
 
     Ok(())
 }

--- a/packages/api/src/target.rs
+++ b/packages/api/src/target.rs
@@ -1,0 +1,1 @@
+pub use wasmer_common_python::py::{CpuFeatures, Target, Triple};

--- a/packages/common/Cargo.toml
+++ b/packages/common/Cargo.toml
@@ -14,3 +14,4 @@ publish = false
 wasmer = { git = "https://github.com/wasmerio/wasmer", default-features = false, features = ["wat", "jit", "native", "compiler"], branch = "master" }
 wasmer-compiler = { git = "https://github.com/wasmerio/wasmer", branch = "master" }
 pyo3 = { version = "0.11", features = ["extension-module"] }
+enumset = "1.0"

--- a/packages/common/src/lib.rs
+++ b/packages/common/src/lib.rs
@@ -1,10 +1,12 @@
 mod engines;
 mod store;
+mod target_lexicon;
 
 pub mod errors;
 pub mod py {
     pub use crate::engines::{Native, OpaqueCompiler, JIT};
     pub use crate::store::Store;
+    pub use crate::target_lexicon::{CpuFeatures, Target, Triple};
 }
 pub mod wasmer {
     pub use wasmer::*;

--- a/packages/common/src/store.rs
+++ b/packages/common/src/store.rs
@@ -95,7 +95,8 @@ impl Store {
                     .and_then(|compiler_module| compiler_module.get("Compiler"))
                     .ok();
 
-                let engine = engines::JIT::raw_new(compiler)?;
+                let target = None;
+                let engine = engines::JIT::raw_new(compiler, target)?;
 
                 (
                     wasmer::Store::new(engine.inner()),

--- a/packages/common/src/target_lexicon.rs
+++ b/packages/common/src/target_lexicon.rs
@@ -1,6 +1,6 @@
 use crate::errors::to_py_err;
 use enumset::EnumSet;
-use pyo3::{exceptions::ValueError, prelude::*};
+use pyo3::{class::basic::PyObjectProtocol, exceptions::ValueError, prelude::*};
 use std::str::FromStr;
 
 #[pyclass]
@@ -129,6 +129,13 @@ impl Triple {
                 wasmer_compiler::CallingConvention::WasmBasicCAbi => "wasm_basic_c_abi",
                 wasmer_compiler::CallingConvention::WindowsFastcall => "windows_fastcall",
             })
+    }
+}
+
+#[pyproto]
+impl PyObjectProtocol for Triple {
+    fn __str__(&self) -> PyResult<String> {
+        Ok(self.inner.to_string())
     }
 }
 

--- a/packages/common/src/target_lexicon.rs
+++ b/packages/common/src/target_lexicon.rs
@@ -1,0 +1,166 @@
+use crate::errors::to_py_err;
+use enumset::EnumSet;
+use pyo3::{exceptions::ValueError, prelude::*};
+use std::str::FromStr;
+
+#[pyclass]
+pub struct Target {
+    inner: wasmer_compiler::Target,
+}
+
+impl Target {
+    pub(crate) fn inner(&self) -> &wasmer_compiler::Target {
+        &self.inner
+    }
+}
+
+#[pymethods]
+impl Target {
+    #[new]
+    fn new(triple: &Triple, cpu_features: Option<&CpuFeatures>) -> Self {
+        Self {
+            inner: wasmer_compiler::Target::new(
+                triple.inner().clone(),
+                cpu_features.map_or_else(
+                    || wasmer_compiler::CpuFeature::set(),
+                    |cpu_features| cpu_features.inner().clone(),
+                ),
+            ),
+        }
+    }
+}
+
+/// A target “triple”.
+///
+/// Historically such things had three fields, though they have added
+/// additional fields over time.
+#[pyclass]
+#[text_signature = "(triple)"]
+pub struct Triple {
+    inner: wasmer_compiler::Triple,
+}
+
+impl Triple {
+    pub(crate) fn inner(&self) -> &wasmer_compiler::Triple {
+        &self.inner
+    }
+}
+
+#[pymethods]
+impl Triple {
+    #[new]
+    fn new(triple: &str) -> PyResult<Self> {
+        Ok(Self {
+            inner: wasmer_compiler::Triple::from_str(triple).map_err(to_py_err::<ValueError, _>)?,
+        })
+    }
+
+    /// Build the triple for the current host.
+    #[staticmethod]
+    fn host() -> Self {
+        Self {
+            inner: wasmer_compiler::Triple::host(),
+        }
+    }
+
+    /// Returns the “architecture” (and sometimes the subarchitecture).
+    #[getter]
+    fn architecture(&self) -> String {
+        self.inner.architecture.to_string()
+    }
+
+    /// Returns the “vendor” (whatever that means).
+    #[getter]
+    fn vendor(&self) -> String {
+        self.inner.vendor.to_string()
+    }
+
+    /// Returns the "operating system” (sometimes also the environment).
+    #[getter]
+    fn operating_system(&self) -> String {
+        self.inner.operating_system.to_string()
+    }
+
+    /// Returns the “binary format” (rarely used).
+    #[getter]
+    fn binary_format(&self) -> String {
+        self.inner.binary_format.to_string()
+    }
+
+    /// Returns the “environment” on top of the operating system
+    /// (often omitted for operating systems with a single predominant
+    /// environment).
+    #[getter]
+    fn environment(&self) -> String {
+        self.inner.environment.to_string()
+    }
+
+    /// Returns the endianness of this target's architecture.
+    #[getter]
+    fn endianness(&self) -> Option<&'static str> {
+        self.inner
+            .endianness()
+            .ok()
+            .map(|endianness| match endianness {
+                wasmer_compiler::Endianness::Little => "little",
+                wasmer_compiler::Endianness::Big => "big",
+            })
+    }
+
+    /// Returns the pointer width (in bytes) of this target's
+    /// architecture.
+    #[getter]
+    fn pointer_width(&self) -> Option<u8> {
+        self.inner
+            .pointer_width()
+            .ok()
+            .map(wasmer_compiler::PointerWidth::bytes)
+    }
+
+    /// Returns the default calling convention for the given target
+    /// triple.
+    #[getter]
+    fn default_calling_convention(&self) -> Option<&'static str> {
+        self.inner
+            .default_calling_convention()
+            .ok()
+            .map(|convention| match convention {
+                wasmer_compiler::CallingConvention::SystemV => "system_v",
+                wasmer_compiler::CallingConvention::WasmBasicCAbi => "wasm_basic_c_abi",
+                wasmer_compiler::CallingConvention::WindowsFastcall => "windows_fastcall",
+            })
+    }
+}
+
+/// Represents a set of CPU features.
+#[pyclass]
+#[text_signature = "()"]
+pub struct CpuFeatures {
+    inner: EnumSet<wasmer_compiler::CpuFeature>,
+}
+
+impl CpuFeatures {
+    pub(crate) fn inner(&self) -> &EnumSet<wasmer_compiler::CpuFeature> {
+        &self.inner
+    }
+}
+
+#[pymethods]
+impl CpuFeatures {
+    #[new]
+    fn new() -> Self {
+        Self {
+            inner: wasmer_compiler::CpuFeature::set(),
+        }
+    }
+
+    /// Add a new CPU feature.
+    #[text_signature = "($self, feature)"]
+    fn add(&mut self, feature: &str) -> PyResult<()> {
+        self.inner.insert(
+            wasmer_compiler::CpuFeature::from_str(feature).map_err(to_py_err::<ValueError, _>)?,
+        );
+
+        Ok(())
+    }
+}

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -2,6 +2,8 @@ from wasmer import engine, target, Store, Module
 from wasmer_compiler_cranelift import Compiler
 import itertools
 import os
+import platform
+import pytest
 
 def test_triple():
     triple = target.Triple('x86_64-apple-darwin')
@@ -41,6 +43,7 @@ def test_target_with_default_cpu_features():
     triple = target.Triple.host()
     target_ = target.Target(triple)
 
+@pytest.mark.skipif(platform.system() == 'Windows', reason='Cross-compilation on Windows requires more tooling that are not installed on the CI servers')
 def test_cross_compilation_roundtrip():
     triple = target.Triple('x86_64-linux-musl')
     cpu_features = target.CpuFeatures()
@@ -55,12 +58,12 @@ def test_cross_compilation_roundtrip():
         store,
         """
         (module
-        (type $sum_t (func (param i32 i32) (result i32)))
-        (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
+          (type $sum_t (func (param i32 i32) (result i32)))
+          (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
             local.get $x
             local.get $y
             i32.add)
-        (export "sum" (func $sum_f)))
+          (export "sum" (func $sum_f)))
         """
     )
 

--- a/tests/test_target.py
+++ b/tests/test_target.py
@@ -1,0 +1,67 @@
+from wasmer import engine, target, Store, Module
+from wasmer_compiler_cranelift import Compiler
+import itertools
+import os
+
+def test_triple():
+    triple = target.Triple('x86_64-apple-darwin')
+
+    assert str(triple) == 'x86_64-apple-darwin'
+    assert triple.architecture == 'x86_64'
+    assert triple.vendor == 'apple'
+    assert triple.operating_system == 'darwin'
+    assert triple.binary_format == 'macho'
+    assert triple.environment == 'unknown'
+    assert triple.endianness == 'little'
+    assert triple.pointer_width == 8
+    assert triple.default_calling_convention == 'system_v'
+
+def test_cpu_features():
+    cpu_features = target.CpuFeatures()
+    cpu_features.add('sse2')
+    cpu_features.add('sse3')
+    cpu_features.add('ssse3')
+    cpu_features.add('sse4.1')
+    cpu_features.add('sse4.2')
+    cpu_features.add('popcnt')
+    cpu_features.add('avx')
+    cpu_features.add('bmi')
+    cpu_features.add('bmi2')
+    cpu_features.add('avx2')
+    cpu_features.add('avx512dq')
+    cpu_features.add('avx512vl')
+    cpu_features.add('lzcnt')
+
+def test_target():
+    triple = target.Triple.host()
+    cpu_features = target.CpuFeatures()
+    target_ = target.Target(triple, cpu_features)
+
+def test_target_with_default_cpu_features():
+    triple = target.Triple.host()
+    target_ = target.Target(triple)
+
+def test_cross_compilation_roundtrip():
+    triple = target.Triple('x86_64-linux-musl')
+    cpu_features = target.CpuFeatures()
+    cpu_features.add('sse2')
+
+    target_ = target.Target(triple, cpu_features)
+
+    engine_ = engine.Native(Compiler, target_)
+    store = Store(engine_)
+
+    module = Module(
+        store,
+        """
+        (module
+        (type $sum_t (func (param i32 i32) (result i32)))
+        (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
+            local.get $x
+            local.get $y
+            i32.add)
+        (export "sum" (func $sum_f)))
+        """
+    )
+
+    assert isinstance(module, Module)


### PR DESCRIPTION
This PR creates a new `wasmer.target` submodule, which provides `Target`, `Triple` and `CpuFeatures` classes. Those are used for cross-compilation. Indeed, now, the `JIT` and the `Native` engine constructors support a second parameter: `target=Target`.

Example of cross-compilation to `x86_64-linux-musl`:

```py
from wasmer import engine, target, Store, Module
from wasmer_compiler_cranelift import Compiler

triple = target.Triple('x86_64-linux-musl')
cpu_features = target.CpuFeatures()
cpu_features.add('sse2')

target_ = target.Target(triple, cpu_features)

engine_ = engine.Native(Compiler, target_)
store = Store(engine_)

module = Module(
    store,
    """
    (module
    (type $sum_t (func (param i32 i32) (result i32)))
    (func $sum_f (type $sum_t) (param $x i32) (param $y i32) (result i32)
        local.get $x
        local.get $y
        i32.add)
    (export "sum" (func $sum_f)))
    """
)

assert isinstance(module, Module)
```