### PR TITLE
Initial doctest impl

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,4 +7,5 @@
 /packages/any/dist
 /packages/any/wasmer.egg-info/
 /target
-/tests/__pycache__/
+
+__pycache__/

--- a/conftest.py
+++ b/conftest.py
@@ -1,0 +1,60 @@
+import enum
+import inspect
+
+
+def pytest_generate_tests(metafunc):
+    if 'docexample' in metafunc.fixturenames:
+        import wasmer
+        docexamples = list(collect_doc_tests(wasmer))
+        metafunc.parametrize("docexample", docexamples)
+
+    
+def collect_doc_tests(root):
+    for obj, doc in collect_docs(root):
+        for source in parse_doc_string(doc):
+            yield DocTest(obj, source)
+
+
+def collect_docs(root):
+    if hasattr(root, "__doc__") and root.__doc__ is not None:
+        yield root, root.__doc__
+    
+    if inspect.ismodule(root) or inspect.isclass(root):
+        for name, obj in vars(root).items():
+            if name.startswith("_"):
+                continue
+            
+            yield from collect_docs(obj)
+            
+
+def parse_doc_string(doc):
+    state = ParserState.WAIT_SOURCE
+    current = []
+    
+    for line in doc.splitlines():
+        if state is ParserState.WAIT_SOURCE and line.strip() == "```py":
+            state = ParserState.IN_SOURCE
+        
+        elif state is ParserState.IN_SOURCE and line.strip() != "```":
+            current.append(line)
+        
+        elif state is ParserState.IN_SOURCE and line.strip() == "```":
+            yield "\n".join(current)
+            
+            current = []
+            state = ParserState.WAIT_SOURCE
+    
+
+class ParserState(int, enum.Enum):
+    WAIT_SOURCE = enum.auto()
+    IN_SOURCE = enum.auto()
+
+
+class DocTest:
+    def __init__(self, obj, source):
+        self.obj = obj
+        self.source = source
+
+    def exec(self):
+        co = compile(self.source, filename="foo", mode="exec")
+        exec(co)

--- a/conftest.py
+++ b/conftest.py
@@ -8,42 +8,44 @@ def pytest_generate_tests(metafunc):
         docexamples = list(collect_doc_tests(wasmer))
         metafunc.parametrize("docexample", docexamples)
 
-    
+
 def collect_doc_tests(root):
     for obj, doc in collect_docs(root):
-        for source in parse_doc_string(doc):
-            yield DocTest(obj, source)
+        for start_line, source in parse_doc_string(doc):
+            yield DocTest(obj, source, start_line)
 
 
 def collect_docs(root):
     if hasattr(root, "__doc__") and root.__doc__ is not None:
         yield root, root.__doc__
-    
+
     if inspect.ismodule(root) or inspect.isclass(root):
         for name, obj in vars(root).items():
             if name.startswith("_"):
                 continue
-            
+
             yield from collect_docs(obj)
-            
+
 
 def parse_doc_string(doc):
     state = ParserState.WAIT_SOURCE
+    start_line_idx = None
     current = []
-    
-    for line in doc.splitlines():
+
+    for line_idx, line in enumerate(doc.splitlines()):
         if state is ParserState.WAIT_SOURCE and line.strip() == "```py":
             state = ParserState.IN_SOURCE
-        
+            start_line_idx = line_idx
+
         elif state is ParserState.IN_SOURCE and line.strip() != "```":
             current.append(line)
-        
+
         elif state is ParserState.IN_SOURCE and line.strip() == "```":
-            yield "\n".join(current)
-            
+            yield start_line_idx, "\n".join(current)
+
             current = []
             state = ParserState.WAIT_SOURCE
-    
+
 
 class ParserState(int, enum.Enum):
     WAIT_SOURCE = enum.auto()
@@ -51,10 +53,27 @@ class ParserState(int, enum.Enum):
 
 
 class DocTest:
-    def __init__(self, obj, source):
+    def __init__(self, obj, source, start_line):
         self.obj = obj
         self.source = source
+        self.start_line = start_line
 
     def exec(self):
-        co = compile(self.source, filename="foo", mode="exec")
-        exec(co)
+        # make sure the line numbers between exception and  source agree
+        source = "\n" * self.start_line + self.source
+
+        try:
+            co = compile(source, filename="<doc>", mode="exec")
+            exec(co)
+
+        except Exception as cause:
+            raise DocTestError(self.obj, cause) from cause
+
+
+class DocTestError(Exception):
+    def __str__(self):
+        obj, cause = self.args
+
+        lineno = cause.__traceback__.tb_lineno
+
+        return "Error in docstring of {!r} in line {}: {}".format(obj, lineno, cause)

--- a/conftest.py
+++ b/conftest.py
@@ -67,13 +67,13 @@ class DocTest:
             exec(co)
 
         except Exception as cause:
-            raise DocTestError(self.obj, cause) from cause
+            raise DocTestError(self.obj, self.source, cause) from cause
 
 
 class DocTestError(Exception):
     def __str__(self):
-        obj, cause = self.args
+        obj, source, cause = self.args
 
         lineno = cause.__traceback__.tb_lineno
 
-        return "Error in docstring of {!r} in line {}: {}".format(obj, lineno, cause)
+        return "Error in docstring of {!r} in line {}: {}\n{}".format(obj, lineno, cause, source)

--- a/packages/api/src/externals/global.rs
+++ b/packages/api/src/externals/global.rs
@@ -136,7 +136,7 @@ impl Global {
     /// store = Store()
     ///
     /// global_ = Global(store, Value.i32(42), mutable=False)
-    /// global_type = global.type
+    /// global_type = global_.type
     ///
     /// assert global_type.type == Type.I32
     /// assert global_type.mutable == False

--- a/packages/api/src/externals/memory.rs
+++ b/packages/api/src/externals/memory.rs
@@ -244,7 +244,7 @@ impl Memory {
     /// ## Example
     ///
     /// ```py
-    /// from wasmer import Store, Memory, Instance
+    /// from wasmer import Store, Memory, Module, Instance
     ///
     /// module = Module(Store(), open('tests/tests.wasm', 'rb').read())
     /// instance = Instance(module)

--- a/packages/api/src/import_object.rs
+++ b/packages/api/src/import_object.rs
@@ -174,7 +174,7 @@ impl ImportObject {
     /// ## Example
     ///
     /// ```py
-    /// from wasmer import ImportObject, Function, Memory, MemoryType
+    /// from wasmer import Store, ImportObject, Function, Memory, MemoryType
     ///
     /// store = Store()
     ///

--- a/packages/api/src/lib.rs
+++ b/packages/api/src/lib.rs
@@ -110,6 +110,8 @@ fn wasmer(py: Python, module: &PyModule) -> PyResult<()> {
     /// ## Example
     ///
     /// ```py
+    /// from wasmer import wasm2wat
+    ///
     /// assert wasm2wat(b'\x00asm\x01\x00\x00\x00') == '(module)'
     /// ```
     #[pyfn(module, "wasm2wat")]

--- a/packages/api/src/memory/buffer.rs
+++ b/packages/api/src/memory/buffer.rs
@@ -30,7 +30,7 @@ use std::{
 /// ## Example
 ///
 /// ```py
-/// from wasmer import Memory, MemoryType
+/// from wasmer import Memory, MemoryType, Store
 ///
 /// store = Store()
 /// memory = Memory(store, MemoryType(128, shared=False))

--- a/packages/api/src/types.rs
+++ b/packages/api/src/types.rs
@@ -455,7 +455,7 @@ impl TryFrom<wasmer::ExportType> for ExportType {
 /// ## Example
 ///
 /// ```py
-/// from wasmer import Store, Module, ImportType, FunctionTYpe, GlobalType, TableType, MemoryType, Type
+/// from wasmer import Store, Module, ImportType, FunctionType, GlobalType, TableType, MemoryType, Type
 ///
 /// module = Module(
 ///     Store(),

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,0 +1,2 @@
+def test_docexample(docexample):
+    docexample.exec()

--- a/tests/test_docs.py
+++ b/tests/test_docs.py
@@ -1,2 +1,20 @@
+import pytest
+
+import wasmer
+
+known_issues = {
+    wasmer.Memory.data_size,
+    wasmer.Table.type,
+    wasmer.Store,
+    wasmer.engine,
+    wasmer.target,
+    wasmer.wasi.Environment.generate_import_object,
+    wasmer.wasi.StateBuilder.preopen_directories,
+    wasmer.wasi.StateBuilder.preopen_directory,
+}
+
 def test_docexample(docexample):
+    if docexample.obj in known_issues:
+        pytest.xfail()
+
     docexample.exec()


### PR DESCRIPTION
As discussed in #223, I think testing the documentation requires a custom plugin. At the moment it's very rough around the edges in particular when it comes to error reporting. 

When I run the current state, I already get the following errors:

```
FAILED tests/test_docs.py::test_docexample[docexample2] - NameError: name 'wasm2wat' is not defined
FAILED tests/test_docs.py::test_docexample[docexample8] -   File "foo", line 6
FAILED tests/test_docs.py::test_docexample[docexample15] - NameError: name 'Module' is not defined
FAILED tests/test_docs.py::test_docexample[docexample17] - AssertionError
FAILED tests/test_docs.py::test_docexample[docexample20] - AssertionError
FAILED tests/test_docs.py::test_docexample[docexample25] - NameError: name 'Store' is not defined
FAILED tests/test_docs.py::test_docexample[docexample28] - NameError: name 'Store' is not defined
FAILED tests/test_docs.py::test_docexample[docexample40] - ModuleNotFoundError: No module named 'wasmer_compiler_llvm'
FAILED tests/test_docs.py::test_docexample[docexample44] - ImportError: cannot import name 'FunctionTYpe' from 'wasmer' (/mnt/c/Users/cmp/Documents/Code/SideProjects/wasmer-python/.env/lib/python3.8/site-packages/wasmer.cpython-38-x86_64-linux-gnu.so)
FAILED tests/test_docs.py::test_docexample[docexample49] - ModuleNotFoundError: No module named 'wasmer_compiler_llvm'
FAILED tests/test_docs.py::test_docexample[docexample50] - pyo3_runtime.PanicException: Nor `clang-10` or `clang` has been found, at least one of them is required for the `NativeEngine`: CannotFindBinaryPath
FAILED tests/test_docs.py::test_docexample[docexample55] - AttributeError: 'builtins.StateBuilder' object has no attribute 'generate_import_object'
FAILED tests/test_docs.py::test_docexample[docexample61] - RuntimeError: preopened directory not found: `foo`
FAILED tests/test_docs.py::test_docexample[docexample62] - RuntimeError: preopened directory not found: `foo`
```

One major limitation is that there are no stacktraces:

```
____________________________________________________________________________________________________________________________ test_docexample[docexample61] _____________________________________________________________________________________________________________________________

docexample = <conftest.DocTest object at 0x7ff7d7bcf310>

    def test_docexample(docexample):
>       docexample.exec()

tests/test_docs.py:2:
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _
conftest.py:60: in exec
    exec(co)
_ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _ _

>   ???
E   RuntimeError: preopened directory not found: `foo`

foo:4: RuntimeError
_______________________
```

[My past experiments](https://cprohm.de/article/better-test-output-with-ast-rewriting-and-a-patched-standard-library.html/) however lead me to believe that's also not achievable without monkey patching the standard library, as IPython is doing. TBH. I don't think the result woudl justify the effort. Maye adding a custom exception with a more explanatory repr would already be enough.