### PR TITLE
feat(api) `Exports` implements `PyIterProtocol`

### DIFF
--- a/docs/api/wasmer/index.html
+++ b/docs/api/wasmer/index.html
@@ -225,6 +225,9 @@ assert exports[3].type.shared == False
 <div class="desc"><p>Represents all the exports of an instance. It is built by
 <code><a title="wasmer.Instance.exports" href="#wasmer.Instance.exports">Instance.exports</a></code>.</p>
 <p>Exports can be of kind <code><a title="wasmer.Function" href="#wasmer.Function">Function</a></code>, <code><a title="wasmer.Global" href="#wasmer.Global">Global</a></code>, <code><a title="wasmer.Table" href="#wasmer.Table">Table</a></code>, or <code><a title="wasmer.Memory" href="#wasmer.Memory">Memory</a></code>.</p>
+<p>The <code><a title="wasmer.Exports" href="#wasmer.Exports">Exports</a></code> class implement <a href="https://docs.python.org/3/c-api/iter.html">the Iterator
+Protocol</a>. Please see
+the <code><a title="wasmer.ExportsIterator" href="#wasmer.ExportsIterator">ExportsIterator</a></code> class.</p>
 <h2 id="example">Example</h2>
 <pre><code class="language-py">from wasmer import Store, Module, Instance, Exports, Function, Global, Table, Memory
 
@@ -246,6 +249,30 @@ assert isinstance(exports.func, Function)
 assert isinstance(exports.glob, Global)
 assert isinstance(exports.tab, Table)
 assert isinstance(exports.mem, Memory)
+</code></pre></div>
+</dd>
+<dt id="wasmer.ExportsIterator"><code class="flex name class">
+<span>class <span class="ident">ExportsIterator</span></span>
+<span>(</span><span>...)</span>
+</code></dt>
+<dd>
+<div class="desc"><p>Iterator over all the exports of an <code><a title="wasmer.Instance" href="#wasmer.Instance">Instance</a></code>.</p>
+<h2 id="example">Example</h2>
+<pre><code class="language-py">from wasmer import Store, Module, Instance, Exports, Function, Global, Table, Memory
+
+module = Module(
+    Store(),
+    &quot;&quot;&quot;
+    (module
+      (func (export &quot;func&quot;) (param i32 i64))
+      (global (export &quot;glob&quot;) i32 (i32.const 7))
+      (table (export &quot;tab&quot;) 0 funcref)
+      (memory (export &quot;mem&quot;) 1))
+    &quot;&quot;&quot;
+)
+instance = Instance(module)
+
+assert [name for (name, export) in instance.exports] == [&quot;func&quot;, &quot;glob&quot;, &quot;tab&quot;, &quot;mem&quot;]
 </code></pre></div>
 </dd>
 <dt id="wasmer.Function"><code class="flex name class">
@@ -1634,6 +1661,9 @@ value = Value.v128(42)
 </li>
 <li>
 <h4><code><a title="wasmer.Exports" href="#wasmer.Exports">Exports</a></code></h4>
+</li>
+<li>
+<h4><code><a title="wasmer.ExportsIterator" href="#wasmer.ExportsIterator">ExportsIterator</a></code></h4>
 </li>
 <li>
 <h4><code><a title="wasmer.Function" href="#wasmer.Function">Function</a></code></h4>

--- a/packages/api/src/lib.rs
+++ b/packages/api/src/lib.rs
@@ -122,6 +122,7 @@ fn wasmer(py: Python, module: &PyModule) -> PyResult<()> {
 
     // Classes.
     module.add_class::<exports::Exports>()?;
+    module.add_class::<exports::ExportsIterator>()?;
     module.add_class::<externals::Function>()?;
     module.add_class::<externals::Global>()?;
     module.add_class::<externals::Memory>()?;

--- a/tests/test_instance.py
+++ b/tests/test_instance.py
@@ -1,5 +1,5 @@
 import wasmer
-from wasmer import Instance, Module, Store, Exports, Function, Global, Table, Memory
+from wasmer import Instance, Module, Store, Exports, ExportsIterator, Function, Global, Table, Memory
 import os
 import pytest
 
@@ -52,6 +52,51 @@ def test_exports_len():
     instance = Instance(Module(Store(), TEST_BYTES))
 
     assert len(instance.exports) == 13
+
+def test_exports_iterable():
+    module = Module(
+        Store(),
+        """
+        (module
+          (func (export "func") (param i32 i64))
+          (global (export "glob") i32 (i32.const 7))
+          (table (export "tab") 0 funcref)
+          (memory (export "mem") 1))
+        """
+    )
+    instance = Instance(module)
+    exports_iterator = iter(instance.exports)
+
+    assert isinstance(exports_iterator, ExportsIterator)
+
+    (export_name, export) = next(exports_iterator)
+    assert export_name == "func"
+    assert isinstance(export, Function)
+
+    (export_name, export) = next(exports_iterator)
+    assert export_name == "glob"
+    assert isinstance(export, Global)
+
+    (export_name, export) = next(exports_iterator)
+    assert export_name == "tab"
+    assert isinstance(export, Table)
+
+    (export_name, export) = next(exports_iterator)
+    assert export_name == "mem"
+    assert isinstance(export, Memory)
+
+    with pytest.raises(StopIteration):
+        next(exports_iterator)
+
+    # Works in a loop.
+    for (name, export) in instance.exports:
+        assert True
+
+    # Works in a loop with `iter` called while it's not necessary.
+    for (name, export) in iter(instance.exports):
+        assert True
+
+    assert [name for (name, _) in instance.exports] == ["func", "glob", "tab", "mem"]
 
 def test_export_does_not_exist():
     with pytest.raises(LookupError) as context_manager:


### PR DESCRIPTION
This patch updates `Exports` to implement `PyIterProtocol`, aka [the Iterator Protocol](https://docs.python.org/3/c-api/iter.html):

* `Exports.__iter__` returns a new instance of `ExportsIterator`. Due to iterator lifetimes on the Rust side, we have no choice than cloning the content of `Exports`, but it's rather cheap,
* `ExportsIterator.__iter__` returns itself (in case a user calls `iter(instance.exports)` by mistake in a `loop`, which is redundant),
* `ExportsIterator.__next__` returns a pair `(name, export)` if the end of the iterator isn't reached.

Fixes https://github.com/wasmerio/wasmer-python/issues/535.