### PR TITLE
feat(api) Allow a host function to type-hint the result with `None`

### DIFF
--- a/docs/api/wasmer/index.html
+++ b/docs/api/wasmer/index.html
@@ -303,6 +303,37 @@ def sum(x: int, y: int) -&gt; int:
 store = Store()
 function = Function(store, sum)
 </code></pre>
+<p>Here is the mapping table:</p>
+<table>
+<thead>
+<tr>
+<th>Annotations</th>
+<th>WebAssembly type</th>
+</tr>
+</thead>
+<tbody>
+<tr>
+<td><code>int</code>, <code>'i32'</code>, <code>'I32'</code></td>
+<td><code><a title="wasmer.Type.I32" href="#wasmer.Type.I32">Type.I32</a></code></td>
+</tr>
+<tr>
+<td><code>'i64'</code>, <code>'I64'</code></td>
+<td><code><a title="wasmer.Type.I64" href="#wasmer.Type.I64">Type.I64</a></code></td>
+</tr>
+<tr>
+<td><code>float</code>, <code>'f32'</code>, <code>'F32'</code></td>
+<td><code><a title="wasmer.Type.F32" href="#wasmer.Type.F32">Type.F32</a></code></td>
+</tr>
+<tr>
+<td><code>'f64'</code>, <code>'F64'</code></td>
+<td><code><a title="wasmer.Type.F64" href="#wasmer.Type.F64">Type.F64</a></code></td>
+</tr>
+<tr>
+<td><code>None</code></td>
+<td>none (only in <code>return</code> position)</td>
+</tr>
+</tbody>
+</table>
 <p>Second, the same code but without annotations and a <code><a title="wasmer.FunctionType" href="#wasmer.FunctionType">FunctionType</a></code>:</p>
 <pre><code class="language-py">from wasmer import Store, Function, FunctionType, Type
 

--- a/tests/test_function.py
+++ b/tests/test_function.py
@@ -13,11 +13,34 @@ def value_with_type(value):
     return (value, type(value))
 
 def test_constructor_with_annotated_function():
-    def sum(x: int, y: int) -> int:
-        return x + y
-
     store = Store()
+
+    def sum(a: int, b: 'i32', c: 'I32', d: 'i64', e: 'I64', f: float, g: 'f32', h: 'F32', i: 'f64', j: 'F64') -> int:
+        return a + b
+
     function = Function(store, sum)
+    function_type = function.type
+
+    assert function_type.params == [Type.I32, Type.I32, Type.I32, Type.I64, Type.I64, Type.F32, Type.F32, Type.F32, Type.F64, Type.F64]
+    assert function_type.results == [Type.I32]
+
+    def return_none(a: int) -> None:
+        pass
+
+    function = Function(store, return_none)
+    function_type = function.type
+
+    assert function_type.params == [Type.I32]
+    assert function_type.results == []
+
+    def take_none(a: None):
+        pass
+
+    with pytest.raises(RuntimeError) as context_manager:
+        Function(store, take_none)
+
+    exception = context_manager.value
+    assert str(exception) == 'Variable `a` cannot have type `None`'
 
 def test_constructor_with_blank_function():
     def sum(x, y):


### PR DESCRIPTION
When a host function has the type-hint `None` for its result, we
consider it's equivalent to nothing:

```python
def foo() -> None:
    pass
```

is equivalent to:

```python
def foo():
    pass
```

Fixes https://github.com/wasmerio/wasmer-python/issues/534.
Fixes https://github.com/wasmerio/wasmer-python/issues/452.