### PR TITLE
Fix path in from_c example

### DIFF
--- a/examples/appendices/from_c.py
+++ b/examples/appendices/from_c.py
@@ -3,7 +3,7 @@ import os
 
 __dir__ = os.path.dirname(os.path.realpath(__file__))
 
-module = Module(Store(), open(__dir__ + '/add_one.wasm', 'rb').read())
+module = Module(Store(), open(__dir__ + '/from_c.wasm', 'rb').read())
 instance = Instance(module)
 
 result = instance.exports.add_one(1)


### PR DESCRIPTION
```
> python examples/appendices/from_c.py
Traceback (most recent call last):
  File "examples/appendices/from_c.py", line 6, in <module>
    module = Module(Store(), open(__dir__ + '/add_one.wasm', 'rb').read())
FileNotFoundError: [Errno 2] No such file or directory: '/Users/ods/work/github/wasmer-python.git/examples/appendices/add_one.wasm'
```