### PR TITLE
Small tweak and documentation to build wasmer-python

### DIFF
--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ prelude:
 	pip3 install virtualenv
 	virtualenv .env
 	if test -d .env/bin/; then source .env/bin/activate; else source .env/Scripts/activate; fi
-	pip3 install maturin pytest pytest-benchmark twine pdoc
+	pip3 install maturin==0.12.20 pytest pytest-benchmark twine pdoc
 
 	which maturin
 	maturin --version

--- a/packages/api/README.md
+++ b/packages/api/README.md
@@ -266,6 +266,9 @@ $ python examples/appendices/simple.py
 
 ## Testing
 
+To build all tests you'll need LLVM 12.0 in your system. We recommend either installing prepackaged
+libraries with [llvm.sh](https://apt.llvm.org/llvm.sh) or building it yourself with [llvmenv](https://crates.io/crates/llvmenv).
+
 Build all the packages and run the tests:
 
 ```sh


### PR DESCRIPTION
##What

- Add specific version to maturin dep
- Call out that LLVM 12.0 is required to build all compilers

## Why

maturin broke their command-line options with v0.13 ([see changelog](https://github.com/PyO3/maturin/blob/main/Changelog.md#0130---2022-07-09)), preventing `just build api` from working.

## Notes

I've tried at first to install LLVM 12.0.1 using llvmenv, but there were some missing headers in Ubuntu :shrug: Using llvm.sh was the best option to getting everything at once. I've also had to set the `LLVM_SYS_120_PREFIX` env variable to `$(llvm-config-12 --prefix)`

2 tests failed citing the lack of `clang`, is this a required component for further development?

```none
FAILED tests/test_docs.py::test_doctest[<module 'target'>0] - pyo3_runtime.PanicException: Need at least one of `clang-11`, `clang-10`, or `clang` installed in order to use `DylibEngine` when cross-compiling
FAILED tests/test_docs.py::test_doctest[<module 'target'>1] - pyo3_runtime.PanicException: Need at least one of `clang-11`, `clang-10`, or `clang` installed in order to use `DylibEngine` when cross-compiling
```