### PR TITLE
Support for python 3.11

### DIFF
--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -138,7 +138,7 @@ jobs:
           export PATH="$HOME/.pyenv/versions/$(cat .python-version)/bin:$PATH"
           if test -d .env/bin/; then source .env/bin/activate; else source .env/Scripts/activate; fi
           maturin list-python
-          PYTHON_INTERPRETER=$(maturin list-python | grep -o "CPython $(cat .python-version | grep -o -E '^[^\.]+\.[^\.]+').* at .*" | cut -d' ' -f 4 | tr '\\' '/')
+          PYTHON_INTERPRETER=$(maturin list-python 2>&1 | grep -o "CPython $(cat .python-version | grep -o -E '^[^\.]+\.[^\.]+').* at .*" | cut -d' ' -f 4 | tr '\\' '/')
           echo "Selected interpreter: ${PYTHON_INTERPRETER}"
           just build-all "${{ matrix.target.target-name }}"
 
@@ -157,7 +157,7 @@ jobs:
           export PATH="$HOME/.pyenv/versions/$(cat .python-version)/bin:$PATH"
           if test -d .env/bin/; then source .env/bin/activate; else source .env/Scripts/activate; fi
           maturin list-python
-          PYTHON_INTERPRETER=$(maturin list-python | grep -o "CPython $(cat .python-version | grep -o -E '^[^\.]+\.[^\.]+').* at .*" | cut -d' ' -f 4 | tr '\\' '/')
+          PYTHON_INTERPRETER=$(maturin list-python 2>&1 | grep -o "CPython $(cat .python-version | grep -o -E '^[^\.]+\.[^\.]+').* at .*" | cut -d' ' -f 4 | tr '\\' '/')
           echo "Selected interpreter: ${PYTHON_INTERPRETER}"
           just build-all-wheels "${PYTHON_INTERPRETER}" "${{ matrix.target.target-name }}"
           just build-any-wheel

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -206,13 +206,13 @@ jobs:
       - name: Set current Python version
         shell: bash
         run: |
-          echo "3.9" > .python-version
+          echo "3.11" > .python-version
 
       - name: Set up Python ${{ matrix.python }} (amd64)
         if: matrix.target.id != 'linux-aarch64'
         uses: actions/setup-python@v1
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Set up Python ${{ matrix.python }} (aarch64)
         if: matrix.target.id == 'linux-aarch64'
@@ -222,7 +222,7 @@ jobs:
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           eval "$(pyenv virtualenv-init -)"
-          pyenv install --list | grep '^  3.9' | tail -n 1 | tr -d '[:space:]' > .python-version
+          pyenv install --list | grep '^  3.11' | tail -n 1 | tr -d '[:space:]' > .python-version
           pyenv install --skip-existing "$(cat .python-version)"
 
       # Caching is disabled because it interferes with artifact creation

--- a/.github/workflows/release.yml
+++ b/.github/workflows/release.yml
@@ -11,10 +11,10 @@ jobs:
 
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         target:
           - id: 'linux-amd64'
-            os: 'ubuntu-18.04'
+            os: 'ubuntu-latest'
             target-name: 'x86_64-unknown-linux-gnu'
             rust-toolchain: 'stable'
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz'
@@ -178,7 +178,7 @@ jobs:
   release:
     name: Release
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
 
     needs: [build]
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -173,7 +173,7 @@ jobs:
           export PATH="$HOME/.pyenv/versions/$(cat .python-version)/bin:$PATH"
           if test -d .env/bin/; then source .env/bin/activate; else source .env/Scripts/activate; fi
           maturin list-python
-          PYTHON_INTERPRETER=$(maturin list-python | grep -o "CPython $(cat .python-version | grep -o -E '^[^\.]+\.[^\.]+').* at .*" | cut -d' ' -f 4 | tr '\\' '/')
+          PYTHON_INTERPRETER=$(maturin list-python 2>&1 | grep -o "CPython $(cat .python-version | grep -o -E '^[^\.]+\.[^\.]+').* at .*" | cut -d' ' -f 4 | tr '\\' '/')
           echo "Selected interpreter: ${PYTHON_INTERPRETER}"
           just build-all "${{ matrix.target.target-name }}"
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -11,16 +11,21 @@ on:
     branches:
       - '**'
 
+# Allow one concurrent deployment
+concurrency:
+  group: ${{ github.ref }}-test
+  cancel-in-progress: true
+
 jobs:
   test:
     name: Build and Test
 
     strategy:
       matrix:
-        python: ["3.7", "3.8", "3.9", "3.10"]
+        python: ["3.7", "3.8", "3.9", "3.10", "3.11"]
         target:
           - id: 'linux-amd64'
-            os: 'ubuntu-18.04'
+            os: 'ubuntu-latest'
             target-name: 'x86_64-unknown-linux-gnu'
             rust-toolchain: 'stable'
             llvm_url: 'https://github.com/llvm/llvm-project/releases/download/llvmorg-13.0.0/clang+llvm-13.0.0-x86_64-linux-gnu-ubuntu-16.04.tar.xz'
@@ -67,7 +72,9 @@ jobs:
           target: ${{ matrix.target.target-name }}
 
       # Caching is disabled because it interferes with artifact creation
-      #- uses: Swatinem/rust-cache@v1
+      # - uses: Swatinem/rust-cache@v2
+      #   with:
+      #     shared-key: "rust-cache"
 
       - name: Set current Python version
         shell: bash
@@ -76,7 +83,7 @@ jobs:
 
       - name: Set up Python ${{ matrix.python }} (amd64)
         if: matrix.target.id != 'linux-aarch64'
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
 
@@ -99,10 +106,7 @@ jobs:
           cd 'C:\Program Files\LLVM\'
           LLVM_DIR=$(pwd)
           echo "LLVM_SYS_120_PREFIX=${LLVM_DIR}" >> $GITHUB_ENV
-      - name: Install LLVM (macOS Apple Silicon)
-        if: matrix.target.os == 'macos-latest' && !matrix.target.llvm_url
-        run: |
-          brew install llvm
+
       - name: Install LLVM
         if: matrix.target.llvm_url
         shell: bash
@@ -190,7 +194,7 @@ jobs:
   prerelease:
     name: Pre-Release
 
-    runs-on: ubuntu-18.04
+    runs-on: ubuntu-latest
     if: startsWith(github.ref, 'refs/heads/prepare-')
 
     needs: [test]
@@ -212,13 +216,13 @@ jobs:
       - name: Set current Python version
         shell: bash
         run: |
-          echo "3.9" > .python-version
+          echo "3.11" > .python-version
 
       - name: Set up Python ${{ matrix.python }} (amd64)
         if: matrix.target.id != 'linux-aarch64'
-        uses: actions/setup-python@v1
+        uses: actions/setup-python@v4
         with:
-          python-version: 3.9
+          python-version: 3.11
 
       - name: Set up Python ${{ matrix.python }} (aarch64)
         if: matrix.target.id == 'linux-aarch64'
@@ -228,7 +232,7 @@ jobs:
           export PATH="$HOME/.pyenv/bin:$PATH"
           eval "$(pyenv init -)"
           eval "$(pyenv virtualenv-init -)"
-          pyenv install --list | grep '^  3.9' | tail -n 1 | tr -d '[:space:]' > .python-version
+          pyenv install --list | grep '^  3.11' | tail -n 1 | tr -d '[:space:]' > .python-version
           pyenv install --skip-existing "$(cat .python-version)"
 
       # Caching is disabled because it interferes with artifact creation

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -48,7 +48,7 @@ jobs:
             rust-toolchain: 'stable'
             # llvm_url: 'https://github.com/wasmerio/llvm-custom-builds/releases/download/11.x/windows-amd64.tar.gz'
             llvm_choco_version: 13.0.0
-      fail-fast: true
+      fail-fast: false
 
     runs-on: ${{ matrix.target.os }}
 

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -190,7 +190,7 @@ jobs:
           export PATH="$HOME/.pyenv/versions/$(cat .python-version)/bin:$PATH"
           if test -d .env/bin/; then source .env/bin/activate; else source .env/Scripts/activate; fi
           maturin list-python
-          PYTHON_INTERPRETER=$(maturin list-python | grep -o "CPython $(cat .python-version | grep -o -E '^[^\.]+\.[^\.]+').* at .*" | cut -d' ' -f 4 | tr '\\' '/')
+          PYTHON_INTERPRETER=$(maturin list-python 2>&1 | grep -o "CPython $(cat .python-version | grep -o -E '^[^\.]+\.[^\.]+').* at .*" | cut -d' ' -f 4 | tr '\\' '/')
           echo "Selected interpreter: ${PYTHON_INTERPRETER}"
           just build-all-wheels "${PYTHON_INTERPRETER}" "${{ matrix.target.target-name }}"
           just build-any-wheel

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,8 +162,6 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           export PATH="$HOME/.pyenv/versions/$(cat .python-version)/bin:$PATH"
           just prelude
-      - name: shell
-        uses: lhotari/action-upterm@v1
 
 
       - name: Compile the library

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,6 +114,8 @@ jobs:
           python -VV
         shell: pwsh
 
+      - name: shell
+        uses: lhotari/action-upterm@v1
 
       - name: Install LLVM (Choco - Windows)
         if: matrix.target.llvm_choco_version

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -99,6 +99,16 @@ jobs:
           pyenv install --list | grep '^  ${{ matrix.python }}' | tail -n 1 | tr -d '[:space:]' > .python-version
           pyenv install --skip-existing "$(cat .python-version)"
 
+      - name: Validate python version
+        run: |
+          $pythonVersion = (python --version)
+          if ("Python ${{ matrix.python }}" -ne "$pythonVersion"){
+            Write-Host "The current version is $pythonVersion; expected version is ${{ matrix.python }}"
+            exit 1
+          }
+          $pythonVersion
+        shell: pwsh
+
       - name: Install LLVM (Choco - Windows)
         if: matrix.target.llvm_choco_version
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -162,6 +162,9 @@ jobs:
           export PATH="$HOME/.cargo/bin:$PATH"
           export PATH="$HOME/.pyenv/versions/$(cat .python-version)/bin:$PATH"
           just prelude
+      - name: shell
+        uses: lhotari/action-upterm@v1
+
 
       - name: Compile the library
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -86,6 +86,7 @@ jobs:
         uses: actions/setup-python@v4
         with:
           python-version: ${{ matrix.python }}
+          architecture: x64
 
       - name: Set up Python ${{ matrix.python }} (aarch64)
         if: matrix.target.id == 'linux-aarch64'

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -114,9 +114,6 @@ jobs:
           python -VV
         shell: pwsh
 
-      - name: shell
-        uses: lhotari/action-upterm@v1
-
       - name: Install LLVM (Choco - Windows)
         if: matrix.target.llvm_choco_version
         shell: bash

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -101,7 +101,8 @@ jobs:
 
       - name: Validate python version
         run: |
-          $pythonVersion = (python --version)
+          $pythonVersionFull = (python --version)
+          $pythonVersion = $pythonVersionFull -replace '\.(\d+)$',''
           if ("Python ${{ matrix.python }}" -ne "$pythonVersion"){
             Write-Host "The current version is $pythonVersion; expected version is ${{ matrix.python }}"
             exit 1

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -109,6 +109,11 @@ jobs:
           }
           $pythonVersion
         shell: pwsh
+      - name: Print python version (verbose)
+        run: |
+          python -VV
+        shell: pwsh
+
 
       - name: Install LLVM (Choco - Windows)
         if: matrix.target.llvm_choco_version

--- a/justfile
+++ b/justfile
@@ -6,7 +6,7 @@ prelude:
 	pip3 install virtualenv
 	virtualenv .env
 	if test -d .env/bin/; then source .env/bin/activate; else source .env/Scripts/activate; fi
-	pip3 install maturin==0.12.20 pytest pytest-benchmark twine pdoc
+	pip3 install maturin==0.14.17 pytest pytest-benchmark twine pdoc
 
 	which maturin
 	maturin --version
@@ -65,7 +65,7 @@ build package='api' rust_target=`rustc -vV | awk '/^host/ { print $2 }'`:
 
         cd packages/{{package}}/
 
-        maturin develop --binding-crate pyo3 --release --strip --cargo-extra-args="${build_args}"
+        maturin develop --binding-crate pyo3 --release --strip
 
 # Build all the wheels.
 build-all-wheels python_version rust_target:
@@ -108,7 +108,7 @@ build-wheel package python_version rust_target:
 
         cd packages/{{package}}
 
-        maturin build --bindings pyo3 --release --target "{{ rust_target }}" --strip --cargo-extra-args="${build_args}" --interpreter "{{python_version}}"
+        maturin build --bindings pyo3 --release --target "{{ rust_target }}" --strip --interpreter "{{python_version}}"
 
 # Create a distribution of wasmer that can be installed anywhere (it will fail on import)
 build-any-wheel:

--- a/packages/api/Cargo.toml
+++ b/packages/api/Cargo.toml
@@ -36,6 +36,7 @@ classifier = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Rust",
     "Topic :: Software Development",

--- a/packages/api/Cargo.toml
+++ b/packages/api/Cargo.toml
@@ -27,26 +27,3 @@ cfg-if = "1.0"
 
 [build-dependencies]
 pyo3-build-config = "0.15"
-
-[package.metadata.maturin]
-classifier = [
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Rust",
-    "Topic :: Software Development",
-    "Topic :: Software Development :: Compilers",
-    "Topic :: Software Development :: Interpreters",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-]
-
-[package.metadata.maturin.project-url]
-"Source Code" = "https://github.com/wasmerio/wasmer-python/"
-"Bug Tracker" = "https://github.com/wasmerio/wasmer-python/issues"
-"Documentation" = "https://github.com/wasmerio/wasmer-python/"

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "wasmer"
+version = "1.1.0"
+description = "Python extension to run WebAssembly binaries"
+readme = "README.md"
+repository = "https://github.com/wasmerio/wasmer-python"
+keywords = ["python", "extension", "webassembly"]
+categories = ["wasm"]
+build = "build.rs"
+
+[package]
+edition = "2018"
+
+[build-system]
+requires = ["maturin>=0.14,<0.15"]
+build-backend = "maturin"
+
+[tool.maturin.metadata]
+category = ["Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Rust",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Compilers",
+    "Topic :: Software Development :: Interpreters",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"]
+
+
+[tool.maturin.project-url]
+"Source Code" = "https://github.com/wasmerio/wasmer-python/"
+"Bug Tracker" = "https://github.com/wasmerio/wasmer-python/issues"
+"Documentation" = "https://github.com/wasmerio/wasmer-python/"

--- a/packages/api/pyproject.toml
+++ b/packages/api/pyproject.toml
@@ -1,13 +1,3 @@
-[project]
-name = "wasmer"
-version = "1.1.0"
-description = "Python extension to run WebAssembly binaries"
-readme = "README.md"
-repository = "https://github.com/wasmerio/wasmer-python"
-keywords = ["python", "extension", "webassembly"]
-categories = ["wasm"]
-build = "build.rs"
-
 [package]
 edition = "2018"
 

--- a/packages/compiler-cranelift/Cargo.toml
+++ b/packages/compiler-cranelift/Cargo.toml
@@ -27,6 +27,7 @@ classifier = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Rust",
     "Topic :: Software Development",

--- a/packages/compiler-cranelift/Cargo.toml
+++ b/packages/compiler-cranelift/Cargo.toml
@@ -18,26 +18,3 @@ crate-type = ["cdylib"]
 wasmer-engines = { path = "../engines/" }
 wasmer-compiler-cranelift = "2.1.1"
 pyo3 = { version = "0.14", features = ["extension-module"] }
-
-[package.metadata.maturin]
-classifier = [
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Rust",
-    "Topic :: Software Development",
-    "Topic :: Software Development :: Compilers",
-    "Topic :: Software Development :: Interpreters",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-]
-
-[package.metadata.maturin.project-url]
-"Source Code" = "https://github.com/wasmerio/wasmer-python/"
-"Bug Tracker" = "https://github.com/wasmerio/wasmer-python/issues"
-"Documentation" = "https://github.com/wasmerio/wasmer-python/"

--- a/packages/compiler-cranelift/pyproject.toml
+++ b/packages/compiler-cranelift/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "wasmer"
+version = "1.1.0"
+description = "Python extension to run WebAssembly binaries"
+readme = "README.md"
+repository = "https://github.com/wasmerio/wasmer-python"
+keywords = ["python", "extension", "webassembly"]
+categories = ["wasm"]
+build = "build.rs"
+
+[package]
+edition = "2018"
+
+[build-system]
+requires = ["maturin>=0.14,<0.15"]
+build-backend = "maturin"
+
+[tool.maturin.metadata]
+category = ["Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Rust",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Compilers",
+    "Topic :: Software Development :: Interpreters",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"]
+
+
+[tool.maturin.project-url]
+"Source Code" = "https://github.com/wasmerio/wasmer-python/"
+"Bug Tracker" = "https://github.com/wasmerio/wasmer-python/issues"
+"Documentation" = "https://github.com/wasmerio/wasmer-python/"

--- a/packages/compiler-cranelift/pyproject.toml
+++ b/packages/compiler-cranelift/pyproject.toml
@@ -1,13 +1,3 @@
-[project]
-name = "wasmer_compiler_cranelift"
-version = "1.1.0"
-description = "Python extension to run WebAssembly binaries"
-readme = "README.md"
-repository = "https://github.com/wasmerio/wasmer-python"
-keywords = ["python", "extension", "webassembly"]
-categories = ["wasm"]
-build = "build.rs"
-
 [package]
 edition = "2018"
 

--- a/packages/compiler-cranelift/pyproject.toml
+++ b/packages/compiler-cranelift/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "wasmer"
+name = "wasmer_compiler_cranelift"
 version = "1.1.0"
 description = "Python extension to run WebAssembly binaries"
 readme = "README.md"

--- a/packages/compiler-llvm/Cargo.toml
+++ b/packages/compiler-llvm/Cargo.toml
@@ -18,26 +18,3 @@ crate-type = ["cdylib"]
 wasmer-engines = { path = "../engines/" }
 wasmer-compiler-llvm = "2.1.1"
 pyo3 = { version = "0.14", features = ["extension-module"] }
-
-[package.metadata.maturin]
-classifier = [
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Rust",
-    "Topic :: Software Development",
-    "Topic :: Software Development :: Compilers",
-    "Topic :: Software Development :: Interpreters",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-]
-
-[package.metadata.maturin.project-url]
-"Source Code" = "https://github.com/wasmerio/wasmer-python/"
-"Bug Tracker" = "https://github.com/wasmerio/wasmer-python/issues"
-"Documentation" = "https://github.com/wasmerio/wasmer-python/"

--- a/packages/compiler-llvm/Cargo.toml
+++ b/packages/compiler-llvm/Cargo.toml
@@ -27,6 +27,7 @@ classifier = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Rust",
     "Topic :: Software Development",

--- a/packages/compiler-llvm/pyproject.toml
+++ b/packages/compiler-llvm/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "wasmer"
+version = "1.1.0"
+description = "Python extension to run WebAssembly binaries"
+readme = "README.md"
+repository = "https://github.com/wasmerio/wasmer-python"
+keywords = ["python", "extension", "webassembly"]
+categories = ["wasm"]
+build = "build.rs"
+
+[package]
+edition = "2018"
+
+[build-system]
+requires = ["maturin>=0.14,<0.15"]
+build-backend = "maturin"
+
+[tool.maturin.metadata]
+category = ["Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Rust",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Compilers",
+    "Topic :: Software Development :: Interpreters",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"]
+
+
+[tool.maturin.project-url]
+"Source Code" = "https://github.com/wasmerio/wasmer-python/"
+"Bug Tracker" = "https://github.com/wasmerio/wasmer-python/issues"
+"Documentation" = "https://github.com/wasmerio/wasmer-python/"

--- a/packages/compiler-llvm/pyproject.toml
+++ b/packages/compiler-llvm/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "wasmer"
+name = "wasmer_compiler_llvm"
 version = "1.1.0"
 description = "Python extension to run WebAssembly binaries"
 readme = "README.md"

--- a/packages/compiler-llvm/pyproject.toml
+++ b/packages/compiler-llvm/pyproject.toml
@@ -1,13 +1,3 @@
-[project]
-name = "wasmer_compiler_llvm"
-version = "1.1.0"
-description = "Python extension to run WebAssembly binaries"
-readme = "README.md"
-repository = "https://github.com/wasmerio/wasmer-python"
-keywords = ["python", "extension", "webassembly"]
-categories = ["wasm"]
-build = "build.rs"
-
 [package]
 edition = "2018"
 

--- a/packages/compiler-singlepass/Cargo.toml
+++ b/packages/compiler-singlepass/Cargo.toml
@@ -27,6 +27,7 @@ classifier = [
     "Programming Language :: Python :: 3.8",
     "Programming Language :: Python :: 3.9",
     "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
     "Programming Language :: Python :: Implementation :: CPython",
     "Programming Language :: Rust",
     "Topic :: Software Development",

--- a/packages/compiler-singlepass/Cargo.toml
+++ b/packages/compiler-singlepass/Cargo.toml
@@ -18,26 +18,3 @@ crate-type = ["cdylib"]
 wasmer-engines = { path = "../engines/" }
 wasmer-compiler-singlepass = "2.1.1"
 pyo3 = { version = "0.14", features = ["extension-module"] }
-
-[package.metadata.maturin]
-classifier = [
-    "Programming Language :: Python",
-    "Programming Language :: Python :: 3",
-    "Programming Language :: Python :: 3.7",
-    "Programming Language :: Python :: 3.8",
-    "Programming Language :: Python :: 3.9",
-    "Programming Language :: Python :: 3.10",
-    "Programming Language :: Python :: 3.11",
-    "Programming Language :: Python :: Implementation :: CPython",
-    "Programming Language :: Rust",
-    "Topic :: Software Development",
-    "Topic :: Software Development :: Compilers",
-    "Topic :: Software Development :: Interpreters",
-    "License :: OSI Approved :: MIT License",
-    "Operating System :: OS Independent",
-]
-
-[package.metadata.maturin.project-url]
-"Source Code" = "https://github.com/wasmerio/wasmer-python/"
-"Bug Tracker" = "https://github.com/wasmerio/wasmer-python/issues"
-"Documentation" = "https://github.com/wasmerio/wasmer-python/"

--- a/packages/compiler-singlepass/pyproject.toml
+++ b/packages/compiler-singlepass/pyproject.toml
@@ -1,0 +1,38 @@
+[project]
+name = "wasmer"
+version = "1.1.0"
+description = "Python extension to run WebAssembly binaries"
+readme = "README.md"
+repository = "https://github.com/wasmerio/wasmer-python"
+keywords = ["python", "extension", "webassembly"]
+categories = ["wasm"]
+build = "build.rs"
+
+[package]
+edition = "2018"
+
+[build-system]
+requires = ["maturin>=0.14,<0.15"]
+build-backend = "maturin"
+
+[tool.maturin.metadata]
+category = ["Programming Language :: Python",
+    "Programming Language :: Python :: 3",
+    "Programming Language :: Python :: 3.7",
+    "Programming Language :: Python :: 3.8",
+    "Programming Language :: Python :: 3.9",
+    "Programming Language :: Python :: 3.10",
+    "Programming Language :: Python :: 3.11",
+    "Programming Language :: Python :: Implementation :: CPython",
+    "Programming Language :: Rust",
+    "Topic :: Software Development",
+    "Topic :: Software Development :: Compilers",
+    "Topic :: Software Development :: Interpreters",
+    "License :: OSI Approved :: MIT License",
+    "Operating System :: OS Independent"]
+
+
+[tool.maturin.project-url]
+"Source Code" = "https://github.com/wasmerio/wasmer-python/"
+"Bug Tracker" = "https://github.com/wasmerio/wasmer-python/issues"
+"Documentation" = "https://github.com/wasmerio/wasmer-python/"

--- a/packages/compiler-singlepass/pyproject.toml
+++ b/packages/compiler-singlepass/pyproject.toml
@@ -1,5 +1,5 @@
 [project]
-name = "wasmer"
+name = "wasmer_compiler_singlepass"
 version = "1.1.0"
 description = "Python extension to run WebAssembly binaries"
 readme = "README.md"

--- a/packages/compiler-singlepass/pyproject.toml
+++ b/packages/compiler-singlepass/pyproject.toml
@@ -1,13 +1,3 @@
-[project]
-name = "wasmer_compiler_singlepass"
-version = "1.1.0"
-description = "Python extension to run WebAssembly binaries"
-readme = "README.md"
-repository = "https://github.com/wasmerio/wasmer-python"
-keywords = ["python", "extension", "webassembly"]
-categories = ["wasm"]
-build = "build.rs"
-
 [package]
 edition = "2018"
 


### PR DESCRIPTION
This PR is to make wasmer-python run with support for python 3.11

- Adds support for python 3.11 (#696)
- Add support for python 3.10 (#680)
- Moves to latest version of maturin (0.14.17) to fix failing windows builds (#715)

I also wanted to get wasmer-python working on M1 as well, but could not get llvm to compile. That should probably be a separate PR anyway since this one is fixing too many things already.